### PR TITLE
fix: adds default styling for starsvg

### DIFF
--- a/src/Components/StarIcon.tsx
+++ b/src/Components/StarIcon.tsx
@@ -13,7 +13,7 @@ export function StarIcon({
   strokeColor = 'none',
   storkeWidth = 0,
   className = 'star-svg',
-  style
+  style = { display: 'inline' }
 }: StarIconProps) {
   return (
     <svg fill='currentColor' width={size} height={size} viewBox='0 0 24 24' className={className} style={{ ...style }}>


### PR DESCRIPTION
Adds default styling (`display: inline`) to class star-svg to fix v4 bug which causes rating component to render stars vertically.

Reference Issue - #9 

![Screenshot 2022-02-06 at 15 53 38](https://user-images.githubusercontent.com/32552408/152689188-763badb8-81c7-4f94-b2cc-1b2ac7853d6b.png)
