### PR TITLE
resolve next js window and navigator undefined issue

### DIFF
--- a/src/Components/Rating.tsx
+++ b/src/Components/Rating.tsx
@@ -134,7 +134,7 @@ export function Rating({
    * Check for touch devices
    * @returns `boolean`
    */
-  const isTouchDevice = useMemo(() => 'ontouchstart' in window || navigator.maxTouchPoints > 0, [])
+  const isTouchDevice = useMemo(() => !!window?.ontouchstart || (typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0), [])
   const totalIcons = useMemo(() => (allowFraction ? iconsCount * 2 : iconsCount), [allowFraction, iconsCount])
 
   // Convert local rating value to precentage


### PR DESCRIPTION
isTouchDevice is just boolean.
I want to use this library at next js project.
But before window and navigator is init, window and navigator in useMemo is called and they are undefined.
So I add checking this types