### PR TITLE
fix: onClick event was triggered on pointerleave when allowHover is disabled

### DIFF
--- a/src/components/Rating.tsx
+++ b/src/components/Rating.tsx
@@ -221,7 +221,7 @@ export function Rating({
   }
 
   const handlePointerLeave = (event: PointerEvent<HTMLSpanElement>) => {
-    if (isTouchDevice()) handleClick()
+    if (isTouchDevice() && allowHover) handleClick()
 
     dispatch({ type: 'PointerLeave' })
     if (onPointerLeave) onPointerLeave(event)


### PR DESCRIPTION
fix: onClick event was triggered on pointerleave when allowHover is disabled #38 