### PR TITLE
Only trigger touch specific code on touch events

### DIFF
--- a/src/components/Rating.tsx
+++ b/src/components/Rating.tsx
@@ -208,7 +208,7 @@ export function Rating({
   const handlePointerEnter = (event: PointerEvent<HTMLSpanElement>) => {
     if (onPointerEnter) onPointerEnter(event)
     // Enable only on touch devices
-    if (!isTouchDevice()) return
+    if (!isTouchDevice() || event.pointerType !== 'touch') return
 
     handlePointerMove(event)
   }
@@ -221,7 +221,7 @@ export function Rating({
   }
 
   const handlePointerLeave = (event: PointerEvent<HTMLSpanElement>) => {
-    if (isTouchDevice()) handleClick()
+    if (isTouchDevice() && event.pointerType === 'touch') handleClick()
 
     dispatch({ type: 'PointerLeave' })
     if (onPointerLeave) onPointerLeave(event)


### PR DESCRIPTION
In handlePointerEnter, handlePointerLeave this is a separate code path for touch devices, gated by isTouchDevice().

However, just because a device supports touch inputs doesn't mean they are actually being used. For example some laptops have touch screens in addition to trackpad, external mice etc. Therefore we should check to see whether the specific event we are handling is a touch event